### PR TITLE
Distribution packages fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     python_requires='>=3.6',
     install_requires=requirements,
     license='BSD',
+    license_files = ('LICENSE',),
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
-"""asf_search distutils configuration"""
-from setuptools import setup
+"""asf_search setuptools configuration"""
+from setuptools import find_packages, setup
 
 # Loads version number into __version__
 exec(open('asf_search/version.py').read())
@@ -22,12 +21,12 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     url="https://github.com/asfadmin/Discovery-asf_search.git",
-    packages=['asf_search'],
+    packages=find_packages(),
     package_dir={'asf_search': 'asf_search'},
     python_requires='>=3.6',
     install_requires=requirements,
     license='BSD',
-    license_files = ('LICENSE',),
+    license_files=('LICENSE',),
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION

### Incomplete Wheel

If you run
```shell
$ python setup.py sdist bdist_wheel
$ cd dist
$ unzip asf_search-0.2.0-py3-none-any.whl
Archive:  asf_search-0.2.0-py3-none-any.whl
  inflating: asf_search/__init__.py  
  inflating: asf_search/version.py   
  inflating: asf_search-0.2.0.dist-info/LICENSE  
  inflating: asf_search-0.2.0.dist-info/METADATA  
  inflating: asf_search-0.2.0.dist-info/WHEEL  
  inflating: asf_search-0.2.0.dist-info/top_level.txt  
  inflating: asf_search-0.2.0.dist-info/RECORD  
```
you can see that the Wheel doesn't include any of the underlying modules, causing [installs to fail](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=297603&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823) with:
```
import: 'asf_search'
Traceback (most recent call last):
  File "/home/conda/staged-recipes/build_artifacts/asf_search_1617125476022/test_tmp/run_test.py", line 2, in <module>
    import asf_search
  File "/home/conda/staged-recipes/build_artifacts/asf_search_1617125476022/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/lib/python3.9/site-packages/asf_search/__init__.py", line 2, in <module>
    from .constants import *
ModuleNotFoundError: No module named 'asf_search.constants'
```

You can reproduce this with `pip` because [pip prefers wheels](https://packaging.python.org/tutorials/installing-packages/#source-distributions-vs-wheels)

```shell
$ python -m pip install asf-search=0.2.0
$ python -c 'import asf_search'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../python3.8/site-packages/asf_search/__init__.py", line 5, in <module>
    from .baseline import *
ModuleNotFoundError: No module named 'asf_search.baseline'
```

This is due to not correctly [listing the packages](https://github.com/jhkennedy/Discovery-asf_search/pull/1/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L25) -- it's better to let `setuptools` discover packages: https://packaging.python.org/guides/distributing-packages-using-setuptools/?highlight=setup.py#packages

**Note: while the source distribution (sdist) is complete (check by untar-ing `asf_search-0.2.0.tar.gz`), install will still fail because pip builds the wheel locally.**
```shell
$ python -m pip uninstall asf_search
$ python -m pip install asf_search==0.2.0 --no-binary :all: --no-cache-dir
$ python -c 'import asf_search'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../python3.8/site-packages/asf_search/__init__.py", line 2, in <module>
    from .constants import *
ModuleNotFoundError: No module named 'asf_search.constants'
```

### License

Currently, `asf_search` doesn't include the LICENSE file in the distributed package -- [look inside the sdist on PyPI](https://files.pythonhosted.org/packages/ee/8d/8c6a0c7abbb962ba076406dcea0a766f9bbe4ace6ac2b556289a0d37d9d6/asf_search-0.2.0.tar.gz).

Generally, you want to include the LICENSE with the code, and it's [required for distributing on conda-forge](https://conda-forge.org/docs/maintainer/adding_pkgs.html#packaging-the-license-manually)

you can confirm [this](https://github.com/jhkennedy/Discovery-asf_search/pull/1/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R29) add the `LICENSE` file by running `python setup.py sdist` and checking the output `build/asf_search-*.tar.gz`